### PR TITLE
Make sure links in posts have a protocol part

### DIFF
--- a/src/templates/channel/post.coffee
+++ b/src/templates/channel/post.coffee
@@ -70,10 +70,16 @@ update_text = do ->
                     flush_text()
 
                     link = part.value
-                    @$a { href: link, target: "_blank" }, link
-                    unless previews_rendered[link]
-                        previews_rendered[link] = yes
-                        render_preview.call(@up(end: no), view, link)
+                    # Protocol part may be missing (short URLs like
+                    # ur1.ca/8jz57). Make sure there's one or the browser will
+                    # think it's a link to http://example.com/ur1.ca/8jz57.
+                    full_link = link
+                    unless link.match(/^[a-z0-9-]+:/)
+                        full_link = 'http://' + link
+                    @$a { href: full_link, target: "_blank"}, link
+                    unless previews_rendered[full_link]
+                        previews_rendered[full_link] = yes
+                        render_preview.call(@up(end: no), view, full_link)
                 when 'user'
                     flush_text()
 


### PR DESCRIPTION
Short URLs (like ur1.ca/8jzl0 or t.co/DEG1zgjc) are correctly detected as URLs, but there is a little issue when they are rendered in a post: since they don't have a protocol part, browsers consider them as relative paths. So they are turned into links to http://example.com/ur1.ca/8jzl0, which obviously does not work.
This commit changes this behavior by trying to detect an procol part in the beginning of a link and adding "http://" if no protocol part can be found.

This could also be done in the scary URL regex, but it would probably be more complicated, and it would change what the user sees (http://ur1.ca/... vs ur1.ca/...).
