### PR TITLE
Fix channel links not working in Firefox

### DIFF
--- a/src/views/authentication/overlay.coffee
+++ b/src/views/authentication/overlay.coffee
@@ -26,7 +26,8 @@ class exports.OverlayLogin extends BaseView
 
     onClick: (ev) ->
         # Hide when clicking overlay around dialog
-        if ev.srcElement is @el[0]
+        el = ev.target or ev.srcElement
+        if el is @el[0]
             @hide()
 
     onKeydown: (ev) =>

--- a/src/views/channel/post.coffee
+++ b/src/views/channel/post.coffee
@@ -40,7 +40,7 @@ class exports.PostView extends BaseView
         app.router.navigate @model.get('author')?.jid, true
 
     clickUserlink: EventHandler (ev) ->
-        el = ev.srcElement
+        el = ev.target or ev.srcElement
         userid = el and $(el).data('userid')
         if userid
             app.router.navigate userid, true


### PR DESCRIPTION
The fix is trivial (using Event.target instead of the non-standard Event.srcElement if available).
