### PR TITLE
Fix for RID = -1 first request.

### DIFF
--- a/src/handlers/connection.coffee
+++ b/src/handlers/connection.coffee
@@ -26,10 +26,11 @@ class exports.ConnectionHandler extends Backbone.EventHandler
                 send.apply @connection, arguments
 
         # check if the bosh service is reachable
+        randomRid = Math.floor(Math.random() * 4294967295);
         jQuery.ajax
             type:'POST'
             contentType:"text/xml"
-            data:'<body rid="-1" xmlns="http://jabber.org/protocol/httpbind"/>'
+            data:'<body rid="' + randomRid + '" xmlns="http://jabber.org/protocol/httpbind"/>'
             url:config.bosh_service
             processData:off
             success: callback


### PR DESCRIPTION
Buddycloud is sending -1 for initial request ID (rid) to the XMPP server. 

According to the spec this should be a 'large random number' (see http://xmpp.org/extensions/xep-0124.html#rids).

This is one of a number of fixes which is preventing buddycloud from using other XMPP servers (potentially more to come).
