### PR TITLE
XMPP servers do not nessecarily advertise in-band registration

### DIFF
--- a/src/vendor/strophe.register.js
+++ b/src/vendor/strophe.register.js
@@ -120,10 +120,7 @@ Strophe.addConnectionPlugin('register', {
         if (register.length === 0 && mechanisms.length === 0)
             return;
 
-        if (register.length === 0) {
-            that._changeConnectStatus(Strophe.Status.REGIFAIL, null);
-            return;
-        } else this.enabled = true;
+        this.enabled = true;
 
         // send a get request for registration, to get all required data fields
         that._changeConnectStatus(Strophe.Status.REGISTERING, null);


### PR DESCRIPTION
http://xmpp.org/extensions/xep-0077.html#streamfeature

 "Upon receiving a stream header qualified by the 'jabber:client' namespace, a server returns a stream header to the client and MAY announce support for in-band registration"

From RFC2119:
1. MAY   This word, or the adjective "OPTIONAL", mean that an item is
     truly optional.  One vendor may choose to include the item because a
     particular marketplace requires it or because the vendor feels that
     it enhances the product while another vendor may omit the same item.
     An implementation which does not include a particular option MUST be
     prepared to interoperate with another implementation which does
     include the option, though perhaps with reduced functionality. In the
     same vein an implementation which does include a particular option
     MUST be prepared to interoperate with another implementation which
     does not include the option (except, of course, for the feature the
     option provides.)"

/cc @ashward
