### PR TITLE
XEP-0313 compliance

### DIFF
--- a/src/vendor/strophe.buddycloud.js
+++ b/src/vendor/strophe.buddycloud.js
@@ -45,8 +45,8 @@ Strophe.addConnectionPlugin('buddycloud', {
                 throw new Error(plugin + " plugin required!");
         });
 
-        Strophe.addNamespace('FORWARD', "urn:xmpp:forward:tmp");
-        Strophe.addNamespace('MAM', "urn:xmpp:archive#management");
+        Strophe.addNamespace('FORWARD', "urn:xmpp:forward:0");
+        Strophe.addNamespace('MAM', "urn:xmpp:mam:tmp");
 
         // generate _postParsers with the right namespaces
         this._postParsers = this._postParsers_template();
@@ -413,15 +413,14 @@ Strophe.addConnectionPlugin('buddycloud', {
      */
     replayNotifications: function(start, end, success, error) {
         var conn = this._connection;
-        var queryAttrs = { xmlns: Strophe.NS.MAM };
-        if (start)
-            queryAttrs.start = start.toISOString ? start.toISOString() : start;
-        if (end)
-            queryAttrs.end = end.toISOString ? end.toISOString() : end;
         var iq = $iq({ from: conn.jid,
                        to: this.channels.jid,
                        type: 'get' }).
-            c('query', queryAttrs);
+            c('query', { xmlns: Strophe.NS.MAM });
+        if (start)
+            iq.c('start').t(start.toISOString ? start.toISOString() : start).up();
+        if (end)
+            iq.c('end')  .t(end.toISOString   ? end.toISOString()   : end)  .up();
         conn.sendIQ(iq, success, this._errorcode(error));
     },
 


### PR DESCRIPTION
The current code implements the MAM [proto-XEP](http://doomsong.co.uk/extensions/render/message-archive-management.html) instead of [XEP-0313](http://xmpp.org/extensions/xep-0313.html). Luckily very few changes are needed:
- namespaces are different
- `<query start="123" end="456"/>` becomes `<query><start>123</start><end>456</end></query>`

The server must also be updated (pull request [#57](https://github.com/buddycloud/buddycloud-server/pull/57)), as well as the [wiki](https://buddycloud.org/w/index.php?title=XMPP_XEP&diff=1373&oldid=1372).
