### PR TITLE
Adding padding to 'about me' to make it more easily editable when empty

### DIFF
--- a/src/styles/edit.styl
+++ b/src/styles/edit.styl
@@ -83,3 +83,6 @@
     p
       color gray
       transition 400ms
+
+p.description span.data[contenteditable="true"]
+  padding-right: 15px


### PR DESCRIPTION
Edit your personal channel or topic channel and modify the 'about me' so that it is blank. Save.

Click edit, attempt to edit 'about me' text. It is possible (either by getting mouse at exact point or using firebug or similar) but its not very user friendly.

Suggestion is adding "padding-right: 15px;"  this allows it to be more easily clickable even when empty.
