### PR TITLE
Inline mention - 146.667 times better than the previous method

### DIFF
--- a/src/styles/autocomplete.styl
+++ b/src/styles/autocomplete.styl
@@ -1,5 +1,38 @@
-.autocomplete-w1 { position:relative; top:0px; left:0px; margin:6px 0 0 6px; /* IE6 fix: */ _background:none; _margin:1px 0 0 0; }
-.autocomplete { border:1px solid #999; background:#FFF; cursor:default; text-align:left; max-height:350px; overflow:auto; margin:-6px 6px 6px -6px; /* IE6 specific: */ _height:350px;  _margin:0; _overflow-x:hidden; }
-.autocomplete .selected { background:#F0F0F0; }
-.autocomplete div { padding:2px 5px; white-space:nowrap; overflow:hidden; }
-.autocomplete strong { font-weight:normal; color:#3399FF; }
+.autocomplete-w1
+   position relative;
+   top 0px;
+   left 0px;
+   margin 6px 0 0 6px; 
+   /* IE6 fix */ _background none; _margin 1px 0 0 0;
+
+.autocomplete
+   border 1px solid #999;
+   background #FFF;
+   cursor default;
+   text-align left;
+   max-height 350px;
+   overflow auto;
+   margin -6px 6px 6px -6px;
+   /* IE6 specific */ _height 350px;
+   _margin 0;
+   _overflow-x hidden;
+
+.autocomplete div.selected
+  background #F0F0F0
+ 
+.autocomplete div
+  padding 2px 5px
+  white-space nowrap
+  overflow hidden
+  
+ .autocomplete div.selected span
+   background #F0F0F0
+ 
+.autocomplete strong
+  font-weight bold
+  color #83AC35
+ 
+.autocomplete img
+  width 24px
+  margin 2px 10px
+ 

--- a/src/views/base.coffee
+++ b/src/views/base.coffee
@@ -96,7 +96,7 @@ class exports.BaseView extends View
         )
         @autocomplete.template = (entry,  formatResult, currentValue, suggestion) ->
             entry = formatResult suggestion, entry, currentValue
-            return "<img src=\"#{this.options.lookup.suggestions[suggestion].avatar}\"/><span class=\"entry\">#{entry}</span>"
+            return "<img class=\"avatar\" src=\"#{this.options.lookup.suggestions[suggestion].avatar}\"/><span class=\"entry\">#{entry}</span>"
         self = @
         @postsNode.on('subscriber:update', (user) ->
             self.setupInlineMention(element)

--- a/src/views/channel/index.coffee
+++ b/src/views/channel/index.coffee
@@ -21,7 +21,7 @@ class exports.ChannelView extends BaseView
         'scroll': 'on_scroll'
         'click .edit': 'clickEdit'
         'click .save': 'clickSave'
-        'keyup textarea': 'keypress'
+        'keyup .newTopic textarea': 'keypress'
 
     initialize: () ->
         super
@@ -318,47 +318,10 @@ class exports.ChannelView extends BaseView
             @pending_notification.remove()
             delete @pending_notification
 
-    keypress: (ev) ->
-      if !@autocomplete?
-        @setupInlineMention()
-
-    setupInlineMention: ->
-       followers = []
-       postsNode = @model.nodes.get('posts')
-
-       if postsNode? is false
-         setTimeout @setupInlineMention(), 1000
-       postsNode.subscribers.forEach (subscriber) ->
-        if subscriber.get('subscription') is 'none'
-          return
-        jid = subscriber.get 'id'
-        followers.push {jid:jid, gravatar: "#{gravatar jid}"}
-
-       @$('textarea').each ->
-          @autocomplete = $(this).autocomplete(
-            lookup: followers
-            minChars: 1
-            zIndex: 9999
-            searchPrefix: '@'
-            noCache: true
-            searchEverywhere: true
-            dataKey: 'jid'
-            delimiter: ' '
-          )
- 
-       ##@autocomplete.template = (entry,  formatResult, currentValue, suggestion) ->
-       ##return formatResult suggestion, entry, currentValue
-       
-       suggestions = @autocomplete.options.lookup.suggestions         
-       postsNode.on('add', (user) ->
-          jid = user.get('jid')
-          console.debug "Adding suggestion #{jid}"
-          suggestions.push {jid: jid, gravatar: "#{gravatar jid}"}
-       )
-       postsNode.on('remove', (user) ->
-          jid = user.get('jid')
-          console.debug "Removing suggestion #{jid}"
-          newFollowerList = suggestions.filter (user) -> user.jid isnt "#{jid}"
-          suggestions = newFollowerList
-          console.debug suggestions
-       )
+    keypress: () ->
+        if !@autocomplete?
+           @setupInlineMention @$('.newTopic textarea')
+        
+    getPostsNode: () ->
+        console.debug @model       
+        @postsNode = @model.nodes.get('posts')

--- a/src/views/channel/topicpost.coffee
+++ b/src/views/channel/topicpost.coffee
@@ -2,9 +2,11 @@
 { CommentsView } = require './comments'
 { PostView } = require './post'
 { BaseView } = require '../base'
-{ gravatar } = require '../../../util'
 
 class exports.TopicPostView extends BaseView
+
+    events:
+        'keyup .answer textarea': 'keypress'
 
     template: require '../../templates/channel/topicpost'
 
@@ -53,3 +55,11 @@ class exports.TopicPostView extends BaseView
                 @el?.hide()
             else
                 @el?.show()
+                
+
+    keypress: () ->
+        if !@autocomplete?
+          @setupInlineMention @$('.answer textarea')
+    
+    getPostsNode: () ->
+        @postsNode = @parent.parent.model.nodes.get('posts')


### PR DESCRIPTION
- Now includes avatars
- Syling to match the rest of the webclient
- Can dynamically add and remove subscribers, and this is reflected in suggestions
- Autocomplete setup and update in baseview
- Minimal code in topicsbase or (channel) index views
- Stylesheet updated to match others
- Javascript library improved to allow injection of changed lookup data

Had to revert to autocomplete being added in topicspost and index as there was no way of tracking the textareas that had autocomplete added, leading to many, many autocomplete div's overlaying each other when the app tried to update the subscribers. The solution was to go back to putting one copy in each view that is generated, works much better.
