### PR TITLE
Fix header

### DIFF
--- a/src/styles/stream.styl
+++ b/src/styles/stream.styl
@@ -1,6 +1,6 @@
 #poweredby
   right -89px
-  top 15px
+  top 65px
   margin-top 2px
   width 76px
   height 26px
@@ -589,7 +589,7 @@ body > .content
 
 .channelDetails
   width 304px
-  margin-top 96px
+  margin-top 106px
   margin-left -13px
   font-size 12px
   color gray


### PR DESCRIPTION
- Pushes 'powered by buddycloud' down 50px to align with top of posts
- Shifts channel details down just enough
