### PR TITLE
Allow JIDs with '+' symbols once again. Issue #128

### DIFF
--- a/src/controllers/router.coffee
+++ b/src/controllers/router.coffee
@@ -123,7 +123,7 @@ class exports.Router extends Backbone.Router
 
     loadingchannel: (id, domain) ->
         jid = if domain then "#{id}@#{domain}" else id
-        jid = decode(jid.toLowerCase())
+        jid = jid.toLowerCase()
         app.users.target = app.users.get_or_create id: jid
 
         if app.handler.connection.connected


### PR DESCRIPTION
See linked issue.
