### PR TITLE
Make path to "assets" folder configurable

### DIFF
--- a/devconfig.js
+++ b/devconfig.js
@@ -5,6 +5,9 @@ module.exports = {
     port: 3000,
     watch: true,
 
+    // assets folder
+    assets: "assets",
+
     // stylus
     css: {
         compress: true,


### PR DESCRIPTION
This is useful for running several instances with different configurations (domain names, branding?) from the same code base. It will be used in Starfleet Command, the federation testing environment I'll release soon.
